### PR TITLE
Manually rezero swerve modules to absolute encoder outputs

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -15,14 +15,6 @@ package frc.robot.subsystems.drive;
 
 import static edu.wpi.first.units.Units.Volts;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import org.littletonrobotics.junction.AutoLogOutput;
-import org.littletonrobotics.junction.Logger;
-
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.config.ModuleConfig;
 import com.pathplanner.lib.config.PIDConstants;
@@ -30,7 +22,6 @@ import com.pathplanner.lib.config.RobotConfig;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import com.pathplanner.lib.pathfinding.Pathfinding;
 import com.pathplanner.lib.util.PathPlannerLogging;
-
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -51,6 +42,12 @@ import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.subsystems.drive.GyroIO.GyroIOInputs;
 import frc.robot.subsystems.limelights.Limelights;
 import frc.robot.util.LocalADStarAK;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.littletonrobotics.junction.AutoLogOutput;
+import org.littletonrobotics.junction.Logger;
 
 public class Drive extends SubsystemBase {
   private static final double MAX_LINEAR_SPEED = Units.feetToMeters(14.5);
@@ -174,7 +171,6 @@ public class Drive extends SubsystemBase {
     m_LimeLight2.periodic();
     odometryLock.lock(); // Prevents odometry updates while reading data
     gyroIO.updateInputs(gyroInputs);
-    
 
     for (var module : modules) {
       module.updateInputs();
@@ -335,7 +331,7 @@ public class Drive extends SubsystemBase {
   public Rotation2d getRotation() {
     return getPose().getRotation();
   }
-  
+
   /** Resets the current odometry pose. */
   public void setPose(Pose2d pose) {
     poseEstimator.resetPosition(rawGyroRotation, getModulePositions(), pose);
@@ -406,5 +402,12 @@ public class Drive extends SubsystemBase {
     }
 
     return out;
+  }
+
+  /** Get the position of all drive wheels in radians. */
+  public void rezeroModulesRelativeEncoders() {
+    for (Module module : modules) {
+      module.rezeroRelativeEncoder();
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -84,8 +84,7 @@ public class Module {
     // On first cycle, reset relative turn encoder
     // Wait until absolute angle is nonzero in case it wasn't initialized yet
     if (turnRelativeOffset == null && inputs.turnAbsolutePosition.getRadians() != 0.0) {
-      turnRelativeOffset =
-          inputs.turnAbsolutePosition.minus(inputs.turnPosition); // minus(inputs.turnPosition);
+      rezeroRelativeEncoder();
     }
 
     // Run closed loop turn control
@@ -217,5 +216,10 @@ public class Module {
 
   public Rotation2d getRawTurnEncoderPosition() {
     return io.getRawTurnEncoderPosition();
+  }
+
+  public void rezeroRelativeEncoder() {
+    turnRelativeOffset =
+        inputs.turnAbsolutePosition.minus(inputs.turnPosition); // minus(inputs.turnPosition);
   }
 }


### PR DESCRIPTION
Call `Drive::rezeroModulesRelativeEncoders` to reset the offset from the relative encoder to properly reflect the readings from the absolute encoder.